### PR TITLE
Update installation command in the README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ For running all integration tests execute
 
 ## Installing the component
 Run from the command line:
-- `mvn clean install -DskipTests`
+- `mvn clean install -DskipTests -Drelease=true`
 
 ## Using the component in a Flow application
 To use the component in an application using maven,


### PR DESCRIPTION
- If unit tests are skipped, the integration tests can also be skipped.
- On branch '2-1-TICKET#91-ExtraItemsBuffer', the integration tests are failing.